### PR TITLE
feat: add travel mechanics to galaxy map

### DIFF
--- a/components/galaxy-map.tsx
+++ b/components/galaxy-map.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
 import { StarMap } from "./star-map"
 import { MiningInterface } from "./mining-interface"
 import { ProcessingWindow } from "./processing-window"
@@ -13,8 +14,17 @@ interface GalaxyMapProps {
 }
 
 export default function GalaxyMap({ onBack }: GalaxyMapProps) {
-  const { starSystems, selectedSystem, playerLocation, selectSystem, getSecurityColor } =
-    useGalaxyMap()
+  const {
+    starSystems,
+    selectedSystem,
+    playerLocation,
+    destination,
+    traveling,
+    travelProgress,
+    selectSystem,
+    initiateTravel,
+    getSecurityColor,
+  } = useGalaxyMap()
   const {
     miningState,
     minedResources,
@@ -58,19 +68,37 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
       <StarMap
         starSystems={starSystems}
         playerLocation={playerLocation}
-        destination={null}
+        destination={destination}
         selectedSystem={selectedSystem}
-        traveling={false}
+        traveling={traveling}
         selectSystem={selectSystem}
         getSecurityColor={getSecurityColor}
       />
 
+      {traveling && (
+        <div className="space-y-2">
+          <Progress value={travelProgress} />
+        </div>
+      )}
+
       <div className="flex gap-4">
         <Button onClick={onBack}>Back</Button>
-        <Button onClick={handleStartMining} disabled={!selectedSystem || miningState.isActive}>
+        <Button
+          onClick={() => selectedSystem && initiateTravel(selectedSystem)}
+          disabled={!selectedSystem || traveling}
+        >
+          Travel
+        </Button>
+        <Button
+          onClick={handleStartMining}
+          disabled={!selectedSystem || miningState.isActive || traveling}
+        >
           Start Mining
         </Button>
-        <Button onClick={handleStartProcessing} disabled={processingState.isActive}>
+        <Button
+          onClick={handleStartProcessing}
+          disabled={processingState.isActive || traveling}
+        >
           Start Processing
         </Button>
       </div>

--- a/components/star-map.tsx
+++ b/components/star-map.tsx
@@ -55,7 +55,7 @@ export function StarMap({
             stroke={system.id === selectedSystem?.id ? "#fbbf24" : "transparent"}
             strokeWidth={3}
             className="cursor-pointer hover:opacity-80"
-            onClick={() => selectSystem(system)}
+            onClick={() => !traveling && selectSystem(system)}
           />
           <text
             x={system.x}

--- a/hooks/use-galaxy-map.ts
+++ b/hooks/use-galaxy-map.ts
@@ -6,7 +6,11 @@ import { starSystems } from "@/data"
 
 export function useGalaxyMap() {
   const [selectedSystem, setSelectedSystem] = useState<StarSystem | null>(null)
-  const [playerLocation] = useState("1") // Sol system
+  const [playerLocation, setPlayerLocation] = useState("1") // Sol system
+  const [destination, setDestination] = useState<string | null>(null)
+  const [traveling, setTraveling] = useState(false)
+  const [travelProgress, setTravelProgress] = useState(0)
+  const [fuel, setFuel] = useState(100)
 
   const getSecurityColor = (security: StarSystem["security"]) => {
     switch (security) {
@@ -25,6 +29,36 @@ export function useGalaxyMap() {
     setSelectedSystem(system)
   }
 
+  const initiateTravel = (system: StarSystem) => {
+    if (traveling || system.id === playerLocation) return
+    const current = starSystems.find((s) => s.id === playerLocation)
+    if (!current) return
+
+    const distance = Math.hypot(system.x - current.x, system.y - current.y)
+    const fuelCost = distance / 100
+    if (fuel < fuelCost) return
+
+    setDestination(system.id)
+    setTraveling(true)
+    setTravelProgress(0)
+
+    const travelTime = distance * 10
+    const start = Date.now()
+
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - start
+      const progress = Math.min((elapsed / travelTime) * 100, 100)
+      setTravelProgress(progress)
+      if (progress >= 100) {
+        clearInterval(interval)
+        setTraveling(false)
+        setDestination(null)
+        setPlayerLocation(system.id)
+        setFuel((f) => Math.max(f - fuelCost, 0))
+      }
+    }, 100)
+  }
+
   const clearSelection = () => {
     setSelectedSystem(null)
   }
@@ -33,7 +67,12 @@ export function useGalaxyMap() {
     starSystems,
     selectedSystem,
     playerLocation,
+    destination,
+    traveling,
+    travelProgress,
+    fuel,
     selectSystem,
+    initiateTravel,
     clearSelection,
     getSecurityColor,
   }


### PR DESCRIPTION
## Summary
- add destination, travel status and fuel tracking to galaxy map hook
- implement travel initiation with distance-based fuel use and progress
- show travel progress and disable interactions while in transit

## Testing
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689edc7795a08331876a2f2720673453