### PR TITLE
feat: add solar system 3D view

### DIFF
--- a/components/galaxy-map.tsx
+++ b/components/galaxy-map.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { StarMap } from "./star-map"
+import { SolarSystemView } from "./solar-system-view"
 import { MiningInterface } from "./mining-interface"
 import { ProcessingWindow } from "./processing-window"
 import { useGalaxyMap } from "@/hooks/use-galaxy-map"
@@ -65,15 +66,19 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
 
   return (
     <div className="space-y-4">
-      <StarMap
-        starSystems={starSystems}
-        playerLocation={playerLocation}
-        destination={destination}
-        selectedSystem={selectedSystem}
-        traveling={traveling}
-        selectSystem={selectSystem}
-        getSecurityColor={getSecurityColor}
-      />
+      {selectedSystem?.id === playerLocation ? (
+        <SolarSystemView />
+      ) : (
+        <StarMap
+          starSystems={starSystems}
+          playerLocation={playerLocation}
+          destination={destination}
+          selectedSystem={selectedSystem}
+          traveling={traveling}
+          selectSystem={selectSystem}
+          getSecurityColor={getSecurityColor}
+        />
+      )}
 
       {traveling && (
         <div className="space-y-2">

--- a/components/solar-system-view.tsx
+++ b/components/solar-system-view.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { Canvas, useFrame, useThree } from "@react-three/fiber"
+import { OrbitControls } from "@react-three/drei"
+import { useRef, useEffect } from "react"
+import * as THREE from "three"
+
+interface PlanetProps {
+  distance: number
+  size: number
+  speed: number
+  color: string
+}
+
+function Planet({ distance, size, speed, color }: PlanetProps) {
+  const ref = useRef<THREE.Mesh>(null!)
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime() * speed
+    ref.current.position.set(Math.cos(t) * distance, 0, Math.sin(t) * distance)
+  })
+
+  return (
+    <>
+      <mesh ref={ref}>
+        <sphereGeometry args={[size, 32, 32]} />
+        <meshStandardMaterial color={color} />
+      </mesh>
+      <mesh rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[distance - 0.05, distance + 0.05, 64]} />
+        <meshBasicMaterial color="gray" side={THREE.DoubleSide} />
+      </mesh>
+    </>
+  )
+}
+
+function SceneCleanup() {
+  const { gl } = useThree()
+  useEffect(() => {
+    return () => {
+      gl.dispose()
+    }
+  }, [gl])
+  return null
+}
+
+export function SolarSystemView() {
+  return (
+    <Canvas style={{ width: 800, height: 600 }} camera={{ position: [0, 20, 40], fov: 60 }}>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[0, 0, 0]} intensity={2} />
+
+      <mesh>
+        <sphereGeometry args={[2, 32, 32]} />
+        <meshStandardMaterial emissive="yellow" />
+      </mesh>
+
+      <Planet distance={6} size={0.5} speed={1} color="blue" />
+      <Planet distance={10} size={0.8} speed={0.6} color="red" />
+
+      <OrbitControls />
+      <SceneCleanup />
+    </Canvas>
+  )
+}
+
+export default SolarSystemView
+


### PR DESCRIPTION
## Summary
- add `SolarSystemView` component using `react-three/fiber` to render planets and orbits
- toggle between 2D star map and 3D solar view when the player is in their current system

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689f2a3c3b1483318081cbbe657584db