### PR TITLE
Handle pointer lock errors in space controls

### DIFF
--- a/components/space-controls.tsx
+++ b/components/space-controls.tsx
@@ -58,10 +58,28 @@ export function SpaceControls() {
 
   useEffect(() => {
     if (!supported) return
-    const handleClick = () => controlsRef.current?.lock()
+    const handleClick = () => {
+      try {
+        controlsRef.current?.lock()
+      } catch (err) {
+        console.error("Pointer lock failed", err)
+      }
+    }
+    const handlePointerLockError = (err: Event) => {
+      console.error("Pointer lock error", err)
+    }
+    const handleUnlock = () => {
+      console.info("Pointer lock released")
+    }
     const dom = gl.domElement
     dom.addEventListener("click", handleClick)
-    return () => dom.removeEventListener("click", handleClick)
+    dom.addEventListener("pointerlockerror", handlePointerLockError)
+    controlsRef.current?.addEventListener("unlock", handleUnlock)
+    return () => {
+      dom.removeEventListener("click", handleClick)
+      dom.removeEventListener("pointerlockerror", handlePointerLockError)
+      controlsRef.current?.removeEventListener("unlock", handleUnlock)
+    }
   }, [gl, supported])
 
   useFrame((_, delta) => {


### PR DESCRIPTION
## Summary
- handle pointer lock errors gracefully in `SpaceControls`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689f80a15dd48331a882aa0726c1f955