### PR TITLE
feat: add reusable starfield component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -12,18 +11,11 @@ import { FleetManagement } from "@/components/fleet-management"
 import { SocialHub } from "@/components/social-hub"
 import { TradingHub } from "@/components/trading-hub"
 
+import { Starfield } from "@/components/starfield"
+
 import { useNavigation } from "@/hooks/use-navigation"
 import { usePlayer } from "@/hooks/use-player"
 import { Progress } from "@/components/ui/progress"
-
-function mulberry32(a: number) {
-  return function () {
-    let t = (a += 0x6d2b79f5)
-    t = Math.imul(t ^ (t >>> 15), t | 1)
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-  }
-}
 
 const Page = () => {
   const {
@@ -38,34 +30,9 @@ const Page = () => {
   const { level, experience, nextLevelExp } = usePlayer()
   const levelProgress = (experience / nextLevelExp) * 100
 
-  const stars = useMemo(() => {
-    const rng = mulberry32(123456)
-    return Array.from({ length: 300 }, (_, i) => ({
-      id: i,
-      left: `${rng() * 100}%`,
-      top: `${rng() * 100}%`,
-      animationDelay: `${rng() * 3}s`,
-      animationDuration: `${2 + rng() * 2}s`,
-    }))
-  }, [])
-
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-black relative">
-      {/* Starfield background */}
-      <div className="absolute inset-0">
-        {stars.map((star) => (
-          <div
-            key={star.id}
-            className="absolute w-1 h-1 bg-white rounded-full animate-pulse"
-            style={{
-              left: star.left,
-              top: star.top,
-              animationDelay: star.animationDelay,
-              animationDuration: star.animationDuration,
-            }}
-          />
-        ))}
-      </div>
+      <Starfield />
 
       {/* Header */}
       <header className="relative z-10 border-b border-slate-700 bg-slate-900/80 backdrop-blur-sm">

--- a/components/fleet-management.tsx
+++ b/components/fleet-management.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { ArrowLeft, Rocket, Shield, Zap, Package } from "lucide-react"
 import { useFleetManagement } from "@/hooks/use-fleet-management"
+import { Starfield } from "@/components/starfield"
 
 interface FleetManagementProps {
   onBack: () => void
@@ -22,21 +23,7 @@ export function FleetManagement({ onBack }: FleetManagementProps) {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-black relative">
-      {/* Starfield background */}
-      <div className="absolute inset-0">
-        {[...Array(300)].map((_, i) => (
-          <div
-            key={i}
-            className="absolute w-1 h-1 bg-white rounded-full animate-pulse"
-            style={{
-              left: `${Math.random() * 100}%`,
-              top: `${Math.random() * 100}%`,
-              animationDelay: `${Math.random() * 3}s`,
-              animationDuration: `${2 + Math.random() * 2}s`,
-            }}
-          />
-        ))}
-      </div>
+      <Starfield />
 
       {/* Header */}
       <header className="relative z-10 border-b border-slate-700 bg-slate-900/80 backdrop-blur-sm">

--- a/components/starfield.tsx
+++ b/components/starfield.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { memo, useMemo, useRef } from "react"
+
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5)
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+interface StarfieldProps {
+  count?: number
+}
+
+function StarfieldComponent({ count = 300 }: StarfieldProps) {
+  const rng = useMemo(() => mulberry32(123456), [])
+  const stars = useRef<
+    Array<{
+      id: number
+      left: string
+      top: string
+      delay: string
+      duration: string
+    }>
+  >([])
+
+  if (stars.current.length === 0) {
+    stars.current = Array.from({ length: count }, (_, i) => ({
+      id: i,
+      left: `${rng() * 100}%`,
+      top: `${rng() * 100}%`,
+      delay: `${rng() * 3}s`,
+      duration: `${2 + rng() * 2}s`,
+    }))
+  }
+
+  return (
+    <div className="absolute inset-0 pointer-events-none">
+      {stars.current.map((star) => (
+        <div
+          key={star.id}
+          className="absolute w-1 h-1 bg-white rounded-full animate-pulse"
+          style={{
+            left: star.left,
+            top: star.top,
+            animationDelay: star.delay,
+            animationDuration: star.duration,
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export const Starfield = memo(StarfieldComponent)
+
+export default Starfield


### PR DESCRIPTION
## Summary
- add memoized Starfield component for animated background
- replace inline star generation in page and fleet management with Starfield

## Testing
- `pnpm build`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689f8efa2f4c8331ab6e9513002a0846