### PR TITLE
refactor: dynamically load solar system view

### DIFF
--- a/components/galaxy-map.tsx
+++ b/components/galaxy-map.tsx
@@ -2,13 +2,22 @@
 
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
+import dynamic from "next/dynamic"
 import { StarMap } from "./star-map"
-import { SolarSystemView, type OrbitPlanet } from "./solar-system-view"
+import type { OrbitPlanet } from "./solar-system-view"
 import { MiningInterface } from "./mining-interface"
 import { ProcessingWindow } from "./processing-window"
 import { useGalaxyMap } from "@/hooks/use-galaxy-map"
 import { useResourceOperations } from "@/hooks/use-resource-operations"
 import type { MiningTarget, ProcessingRecipe } from "@/types"
+
+const SolarSystemView = dynamic(
+  () => import("./solar-system-view").then((m) => m.SolarSystemView),
+  {
+    ssr: false,
+    loading: () => <div>Loading 3D view...</div>,
+  }
+)
 
 interface GalaxyMapProps {
   onBack: () => void


### PR DESCRIPTION
## Summary
- dynamically import `SolarSystemView` in `GalaxyMap` with `ssr: false`
- show loading fallback while 3D view is loading

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689f91f19c008331800ad412a10d3c03