### PR TITLE
Add pathfinding and route visualization for star travel

### DIFF
--- a/components/galaxy-map.tsx
+++ b/components/galaxy-map.tsx
@@ -75,9 +75,9 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
     starSystems,
     selectedSystem,
     playerLocation,
-    destination,
     traveling,
     travelProgress,
+    travelPath,
     selectSystem,
     initiateTravel,
     getSecurityColor,
@@ -130,9 +130,9 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
         <StarMap
           starSystems={starSystems}
           playerLocation={playerLocation}
-          destination={destination}
           selectedSystem={selectedSystem}
           traveling={traveling}
+          travelPath={travelPath}
           selectSystem={selectSystem}
           getSecurityColor={getSecurityColor}
         />

--- a/components/star-map.tsx
+++ b/components/star-map.tsx
@@ -5,9 +5,9 @@ import type { StarSystem } from "@/types"
 interface StarMapProps {
   starSystems: StarSystem[]
   playerLocation: string
-  destination: string | null
   selectedSystem: StarSystem | null
   traveling: boolean
+  travelPath: string[]
   selectSystem: (system: StarSystem) => void
   getSecurityColor: (sec: StarSystem["security"]) => string
 }
@@ -15,9 +15,9 @@ interface StarMapProps {
 export function StarMap({
   starSystems,
   playerLocation,
-  destination,
   selectedSystem,
   traveling,
+  travelPath,
   selectSystem,
   getSecurityColor,
 }: StarMapProps) {
@@ -68,18 +68,26 @@ export function StarMap({
         </g>
       ))}
 
-      {traveling && destination && selectedSystem && (
-        <line
-          x1={starSystems.find((s) => s.id === playerLocation)?.x || 0}
-          y1={starSystems.find((s) => s.id === playerLocation)?.y || 0}
-          x2={starSystems.find((s) => s.id === destination)?.x || 0}
-          y2={starSystems.find((s) => s.id === destination)?.y || 0}
-          stroke="#10b981"
-          strokeWidth={3}
-          strokeDasharray="5,5"
-          opacity={0.8}
-        />
-      )}
+      {traveling && travelPath.length > 1 &&
+        travelPath.map((id, i) => {
+          if (i === travelPath.length - 1) return null
+          const from = starSystems.find((s) => s.id === id)
+          const to = starSystems.find((s) => s.id === travelPath[i + 1])
+          if (!from || !to) return null
+          return (
+            <line
+              key={`${from.id}-${to.id}`}
+              x1={from.x}
+              y1={from.y}
+              x2={to.x}
+              y2={to.y}
+              stroke="#10b981"
+              strokeWidth={3}
+              strokeDasharray="5,5"
+              opacity={0.8}
+            />
+          )
+        })}
     </svg>
   )
 }

--- a/hooks/use-galaxy-map.ts
+++ b/hooks/use-galaxy-map.ts
@@ -11,6 +11,7 @@ export function useGalaxyMap() {
   const [traveling, setTraveling] = useState(false)
   const [travelProgress, setTravelProgress] = useState(0)
   const [fuel, setFuel] = useState(100)
+  const [travelPath, setTravelPath] = useState<string[]>([])
 
   const getSecurityColor = (security: StarSystem["security"]) => {
     switch (security) {
@@ -29,20 +30,87 @@ export function useGalaxyMap() {
     setSelectedSystem(system)
   }
 
+  const findPath = (startId: string, goalId: string) => {
+    const getSystem = (id: string) => starSystems.find((s) => s.id === id)!
+    const start = getSystem(startId)
+    const goal = getSystem(goalId)
+
+    const openSet = new Set<string>([start.id])
+    const cameFrom = new Map<string, string>()
+    const gScore = new Map<string, number>()
+    const fScore = new Map<string, number>()
+
+    for (const system of starSystems) {
+      gScore.set(system.id, Infinity)
+      fScore.set(system.id, Infinity)
+    }
+    gScore.set(start.id, 0)
+    fScore.set(start.id, Math.hypot(start.x - goal.x, start.y - goal.y))
+
+    while (openSet.size > 0) {
+      let current: string | null = null
+      let currentF = Infinity
+      for (const id of openSet) {
+        const f = fScore.get(id) ?? Infinity
+        if (f < currentF) {
+          currentF = f
+          current = id
+        }
+      }
+
+      if (!current) break
+      if (current === goal.id) {
+        const totalPath = [current]
+        while (cameFrom.has(current)) {
+          current = cameFrom.get(current)!
+          totalPath.unshift(current)
+        }
+        return totalPath
+      }
+
+      openSet.delete(current)
+      const currentSystem = getSystem(current)
+      for (const neighborId of currentSystem.connected) {
+        const neighbor = getSystem(neighborId)
+        const tentativeG =
+          (gScore.get(current) ?? Infinity) +
+          Math.hypot(neighbor.x - currentSystem.x, neighbor.y - currentSystem.y)
+        if (tentativeG < (gScore.get(neighborId) ?? Infinity)) {
+          cameFrom.set(neighborId, current)
+          gScore.set(neighborId, tentativeG)
+          fScore.set(
+            neighborId,
+            tentativeG +
+              Math.hypot(neighbor.x - goal.x, neighbor.y - goal.y),
+          )
+          openSet.add(neighborId)
+        }
+      }
+    }
+
+    return []
+  }
+
   const initiateTravel = (system: StarSystem) => {
     if (traveling || system.id === playerLocation) return
-    const current = starSystems.find((s) => s.id === playerLocation)
-    if (!current) return
+    const path = findPath(playerLocation, system.id)
+    if (path.length < 2) return
 
-    const distance = Math.hypot(system.x - current.x, system.y - current.y)
-    const fuelCost = distance / 100
+    let totalDistance = 0
+    for (let i = 0; i < path.length - 1; i++) {
+      const from = starSystems.find((s) => s.id === path[i])!
+      const to = starSystems.find((s) => s.id === path[i + 1])!
+      totalDistance += Math.hypot(to.x - from.x, to.y - from.y)
+    }
+    const fuelCost = totalDistance / 100
     if (fuel < fuelCost) return
 
     setDestination(system.id)
     setTraveling(true)
     setTravelProgress(0)
+    setTravelPath(path)
 
-    const travelTime = distance * 10
+    const travelTime = totalDistance * 10
     const start = Date.now()
 
     const interval = setInterval(() => {
@@ -55,6 +123,7 @@ export function useGalaxyMap() {
         setDestination(null)
         setPlayerLocation(system.id)
         setFuel((f) => Math.max(f - fuelCost, 0))
+        setTravelPath([])
       }
     }, 100)
   }
@@ -71,6 +140,7 @@ export function useGalaxyMap() {
     traveling,
     travelProgress,
     fuel,
+    travelPath,
     selectSystem,
     initiateTravel,
     clearSelection,


### PR DESCRIPTION
## Summary
- implement A* pathfinding for interstellar travel
- track and render multi-hop travel routes with fuel/time cost
- show progress bar for route traversal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_689f977c69c8833181f5f53f042973ff