### PR TITLE
feat: add planet details modal

### DIFF
--- a/components/galaxy-map.tsx
+++ b/components/galaxy-map.tsx
@@ -10,6 +10,7 @@ import { ProcessingWindow } from "./processing-window"
 import { useGalaxyMap } from "@/hooks/use-galaxy-map"
 import { useResourceOperations } from "@/hooks/use-resource-operations"
 import type { MiningTarget, ProcessingRecipe } from "@/types"
+import { PlanetDetails } from "./planet-details"
 
 const SolarSystemView = dynamic(
   () => import("./solar-system-view").then((m) => m.SolarSystemView),
@@ -81,6 +82,9 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
     selectSystem,
     initiateTravel,
     getSecurityColor,
+    selectedPlanet,
+    selectPlanet,
+    clearSelectedPlanet,
   } = useGalaxyMap()
   const {
     miningState,
@@ -120,7 +124,9 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
     startProcessing(recipe)
   }
 
-  const handlePlanetSelect = (_planet: OrbitPlanet) => {}
+  const handlePlanetSelect = (planet: OrbitPlanet) => {
+    selectPlanet(planet)
+  }
 
   return (
     <div className="space-y-4">
@@ -180,6 +186,7 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
         show={showProcessingInterface}
         onClose={() => setShowProcessingInterface(false)}
       />
+      <PlanetDetails planet={selectedPlanet} onClose={clearSelectedPlanet} />
     </div>
   )
 }

--- a/components/planet-details.tsx
+++ b/components/planet-details.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import type { OrbitPlanet } from "./solar-system-view"
+
+interface PlanetDetailsProps {
+  planet: OrbitPlanet | null
+  onClose: () => void
+}
+
+export function PlanetDetails({ planet, onClose }: PlanetDetailsProps) {
+  if (!planet) return null
+
+  return (
+    <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+      <Card className="bg-slate-900 border-blue-600/50 p-6 max-w-md w-full mx-4">
+        <CardHeader>
+          <CardTitle className="text-blue-400 flex items-center justify-between">
+            {planet.name}
+            <Button onClick={onClose} variant="outline" size="sm">
+              Close
+            </Button>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-slate-300">
+          <div>ID: {planet.id}</div>
+          <div>Size: {planet.size}</div>
+          {planet.type && <div>Type: {planet.type}</div>}
+          <div>Distance from sun: {planet.distance}</div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default PlanetDetails

--- a/hooks/use-galaxy-map.ts
+++ b/hooks/use-galaxy-map.ts
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import type { StarSystem } from "@/types"
 import { starSystems } from "@/data"
+import type { OrbitPlanet } from "@/components/solar-system-view"
 
 export function useGalaxyMap() {
   const [selectedSystem, setSelectedSystem] = useState<StarSystem | null>(null)
@@ -12,6 +13,7 @@ export function useGalaxyMap() {
   const [travelProgress, setTravelProgress] = useState(0)
   const [fuel, setFuel] = useState(100)
   const [travelPath, setTravelPath] = useState<string[]>([])
+  const [selectedPlanet, setSelectedPlanet] = useState<OrbitPlanet | null>(null)
 
   const getSecurityColor = (security: StarSystem["security"]) => {
     switch (security) {
@@ -28,6 +30,10 @@ export function useGalaxyMap() {
 
   const selectSystem = (system: StarSystem) => {
     setSelectedSystem(system)
+  }
+
+  const selectPlanet = (planet: OrbitPlanet) => {
+    setSelectedPlanet(planet)
   }
 
   const findPath = (startId: string, goalId: string) => {
@@ -132,6 +138,10 @@ export function useGalaxyMap() {
     setSelectedSystem(null)
   }
 
+  const clearSelectedPlanet = () => {
+    setSelectedPlanet(null)
+  }
+
   return {
     starSystems,
     selectedSystem,
@@ -145,5 +155,8 @@ export function useGalaxyMap() {
     initiateTravel,
     clearSelection,
     getSecurityColor,
+    selectedPlanet,
+    selectPlanet,
+    clearSelectedPlanet,
   }
 }


### PR DESCRIPTION
## Summary
- implement planet selection in galaxy map to open details modal
- track selected planet in `useGalaxyMap`
- introduce `PlanetDetails` component with close button

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a02abf542483319b14fed67b03a080