### PR TITLE
feat: extend mission details in combat arena

### DIFF
--- a/components/battle-log.tsx
+++ b/components/battle-log.tsx
@@ -1,17 +1,24 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
 import type { BattleLog } from "@/types"
 
 interface BattleLogPanelProps {
   log: BattleLog[]
+  progress: number
+  reward?: number
 }
 
-export function BattleLogPanel({ log }: BattleLogPanelProps) {
+export function BattleLogPanel({ log, progress, reward }: BattleLogPanelProps) {
   return (
     <Card className="bg-slate-900/80 backdrop-blur-sm border-pink-600/30">
       <CardHeader>
         <CardTitle className="text-white">Battle Log</CardTitle>
+        {typeof reward === "number" && (
+          <div className="text-sm text-slate-300 mt-1">Reward: {reward} XP</div>
+        )}
+        <Progress value={progress} className="mt-2" />
       </CardHeader>
       <CardContent className="space-y-1 max-h-[400px] overflow-y-auto">
         {log.map((entry) => (

--- a/components/combat-arena.tsx
+++ b/components/combat-arena.tsx
@@ -29,6 +29,16 @@ export function CombatArena({ onBack }: CombatArenaProps) {
   const { level, experience, nextLevelExp } = useStore((s) => s.player)
   const levelProgress = (experience / nextLevelExp) * 100
 
+  const difficultyColors = {
+    easy: "bg-green-500",
+    medium: "bg-yellow-500",
+    hard: "bg-red-500",
+  }
+
+  const totalEnemies = currentMission?.enemies.length || 0
+  const missionProgress =
+    totalEnemies > 0 ? ((totalEnemies - enemyShips.length) / totalEnemies) * 100 : 0
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-black relative">
       <header className="relative z-10 border-b border-slate-700 bg-slate-900/80 backdrop-blur-sm">
@@ -67,9 +77,19 @@ export function CombatArena({ onBack }: CombatArenaProps) {
                   size="sm"
                   variant={currentMission?.id === mission.id ? "default" : "secondary"}
                   onClick={() => startMission(mission.id)}
-                  className="w-full"
+                  className="w-full flex flex-col items-start text-left gap-1"
                 >
                   {mission.name}
+                  <span className="text-xs text-slate-300">{mission.description}</span>
+                  <span className="text-xs text-slate-300">Reward: {mission.reward} XP</span>
+                  <span className="text-xs text-slate-300 flex items-center">
+                    <span
+                      className={`w-2 h-2 rounded-full mr-1 ${
+                        difficultyColors[mission.difficulty]
+                      }`}
+                    />
+                    {mission.difficulty}
+                  </span>
                 </Button>
               ))}
             </CardContent>
@@ -82,7 +102,11 @@ export function CombatArena({ onBack }: CombatArenaProps) {
           />
         </div>
         <WeaponPanel ship={playerShip} onAttack={handleAttack} />
-        <BattleLogPanel log={battleLog} />
+        <BattleLogPanel
+          log={battleLog}
+          progress={missionProgress}
+          reward={currentMission?.reward}
+        />
       </div>
     </div>
   )

--- a/hooks/use-battle.ts
+++ b/hooks/use-battle.ts
@@ -7,6 +7,9 @@ import { useStore } from "@/store"
 interface Mission {
   id: string
   name: string
+  description: string
+  reward: number
+  difficulty: "easy" | "medium" | "hard"
   enemies: BattleShip[]
 }
 
@@ -33,6 +36,9 @@ const missions: Mission[] = [
   {
     id: "skirmish",
     name: "Pirate Skirmish",
+    description: "Clear out a small pirate scouting party.",
+    reward: 500,
+    difficulty: "easy",
     enemies: [
       {
         id: "enemy1",
@@ -69,6 +75,9 @@ const missions: Mission[] = [
   {
     id: "convoy",
     name: "Convoy Ambush",
+    description: "Escort a convoy under heavy attack.",
+    reward: 800,
+    difficulty: "medium",
     enemies: [
       {
         id: "enemy3",
@@ -336,7 +345,7 @@ export function useBattle() {
     if (isInCombat && enemyShips.length === 0) {
       dispatch({ type: "ADD_LOG", log: createLog(`Mission ${currentMission.name} completed`, "info") })
       setIsInCombat(false)
-      addExperience(500)
+      addExperience(currentMission.reward)
     }
   }, [enemyShips, isInCombat, currentMission, addExperience])
 


### PR DESCRIPTION
## Summary
- expand mission data with description, reward, difficulty
- show mission details with difficulty indicator in Combat Arena
- display mission progress and reward in Battle Log

## Testing
- `pnpm build`
- `pnpm lint` *(fails: asks how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68a037a0ff448331b30e20fdcc99ef22