### PR TITLE
fix: validate canvas presence before requesting pointer lock

### DIFF
--- a/components/space-controls.tsx
+++ b/components/space-controls.tsx
@@ -61,10 +61,14 @@ export function SpaceControls() {
     const dom = gl.domElement
     const handleClick = () => {
       if (!document.pointerLockElement) {
-        try {
-          controlsRef.current?.lock()
-        } catch (err) {
-          console.error("Pointer lock failed", err)
+        if (dom.isConnected || document.contains(dom)) {
+          try {
+            controlsRef.current?.lock()
+          } catch (err) {
+            console.error("Pointer lock failed", err)
+          }
+        } else {
+          console.warn("Pointer lock skipped: canvas is not in the DOM")
         }
       }
     }


### PR DESCRIPTION
## Summary
- ensure pointer lock is only requested if the canvas is still attached to the DOM

## Testing
- `pnpm build`
- `pnpm lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a04766831c833190316b177dec0fe9