### PR TITLE
Add travel state and arrival callback for ship navigation

### DIFF
--- a/components/solar-system-view.tsx
+++ b/components/solar-system-view.tsx
@@ -183,14 +183,15 @@ export function SolarSystemView({ planets, onPlanetSelect }: SolarSystemViewProp
   const [firstPerson, setFirstPerson] = useState(false)
   const shipRef = useRef<THREE.Mesh>(null!)
 
+  const handlePlanetSelect = (p: OrbitPlanet) => {
+    sendShipToPlanet(p, () => onPlanetSelect?.(p))
+  }
+
   return (
     <div className="relative w-full h-screen">
       <PlanetList
         planets={planets}
-        onSelect={(p) => {
-          onPlanetSelect?.(p)
-          sendShipToPlanet(p)
-        }}
+        onSelect={handlePlanetSelect}
         className="absolute left-4 top-4 z-10 w-40"
       />
       <Button
@@ -239,10 +240,7 @@ export function SolarSystemView({ planets, onPlanetSelect }: SolarSystemViewProp
             key={p.id}
             {...p}
             isSelected={destinationPlanet?.id === p.id}
-            onClick={() => {
-              onPlanetSelect?.(p)
-              sendShipToPlanet(p)
-            }}
+            onClick={() => handlePlanetSelect(p)}
             onPositionChange={(pos) => (planetPositions.current[p.id] = pos.clone())}
           />
         ))}

--- a/hooks/use-ship-navigation.ts
+++ b/hooks/use-ship-navigation.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useRef, useState } from "react"
 import * as THREE from "three"
 import type { OrbitPlanet } from "@/components/solar-system-view"
 
@@ -8,9 +8,17 @@ export function useShipNavigation() {
   const [shipPosition, setShipPosition] = useState(() => new THREE.Vector3())
   const [destinationPlanet, setDestinationPlanet] =
     useState<OrbitPlanet | null>(null)
+  const [isTraveling, setIsTraveling] = useState(false)
+  const arrivalCallback = useRef<(() => void) | null>(null)
 
-  const sendShipToPlanet = (planet: OrbitPlanet) => {
+  const sendShipToPlanet = (
+    planet: OrbitPlanet,
+    onArrive?: () => void,
+  ) => {
+    if (isTraveling) return
     setDestinationPlanet(planet)
+    setIsTraveling(true)
+    arrivalCallback.current = onArrive || null
   }
 
   const updateShipPosition = (delta: number) => {
@@ -33,6 +41,9 @@ export function useShipNavigation() {
     if (distance < 0.1) {
       setShipPosition(target)
       setDestinationPlanet(null)
+      setIsTraveling(false)
+      arrivalCallback.current?.()
+      arrivalCallback.current = null
       return
     }
     direction.normalize()
@@ -45,5 +56,6 @@ export function useShipNavigation() {
     destinationPlanet,
     sendShipToPlanet,
     updateShipPosition,
+    isTraveling,
   }
 }


### PR DESCRIPTION
## Summary
- invoke ship travel from planet click through shared handler
- add isTraveling flag and arrival callback to ship navigation hook
- call onPlanetSelect when ship reaches destination planet

## Testing
- `pnpm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a0840cf6748331b7630dcd0e3d765b