### PR TITLE
Use stricter pointer lock availability check

### DIFF
--- a/components/space-controls.tsx
+++ b/components/space-controls.tsx
@@ -53,7 +53,7 @@ export function SpaceControls() {
   }, [])
 
   useEffect(() => {
-    setSupported(typeof document !== "undefined" && "pointerLockElement" in document)
+    setSupported(typeof document !== "undefined" && !!document.body?.requestPointerLock)
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Ensure `SpaceControls` only initializes when the Pointer Lock API is fully available by checking `document.body?.requestPointerLock`

## Testing
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a05dfe8c8331a9602f67146ddb04