### PR TITLE
Reset camera when returning to orbit view

### DIFF
--- a/components/solar-system-view.tsx
+++ b/components/solar-system-view.tsx
@@ -174,6 +174,27 @@ function ThirdPersonCameraController({
   return null
 }
 
+function OrbitViewController({
+  firstPerson,
+  destinationPlanet,
+  maxDistance,
+}: {
+  firstPerson: boolean
+  destinationPlanet: OrbitPlanet | null
+  maxDistance: number
+}) {
+  const { camera } = useThree()
+  const wasFirstPerson = useRef(firstPerson)
+  useEffect(() => {
+    if (wasFirstPerson.current && !firstPerson && !destinationPlanet) {
+      camera.position.set(0, maxDistance * 2, maxDistance * 3)
+      camera.lookAt(0, 0, 0)
+    }
+    wasFirstPerson.current = firstPerson
+  }, [firstPerson, destinationPlanet, camera, maxDistance])
+  return null
+}
+
 function SceneCleanup() {
   const { gl } = useThree()
   useEffect(() => {
@@ -200,6 +221,11 @@ export function SolarSystemView({ planets, onPlanetSelect }: SolarSystemViewProp
     }
     return positions
   }, [])
+
+  const maxDistance = useMemo(
+    () => planets.reduce((max, p) => Math.max(max, p.distance), 0),
+    [planets],
+  )
 
   // const sunTexture = useLoader(TextureLoader, "/textures/sun.jpg")
 
@@ -285,6 +311,11 @@ export function SolarSystemView({ planets, onPlanetSelect }: SolarSystemViewProp
         ) : (
           <ThirdPersonCameraController shipRef={shipRef} />
         )}
+        <OrbitViewController
+          firstPerson={firstPerson}
+          destinationPlanet={destinationPlanet}
+          maxDistance={maxDistance}
+        />
         <CameraController target={destinationPlanet} planetPositions={planetPositions} />
         <SceneCleanup />
       </Canvas>


### PR DESCRIPTION
## Summary
- Compute maximum planet distance to frame the whole system
- Add orbit view controller to reposition camera when leaving first-person mode

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a2de45ea008331beea590633740d90