### PR TITLE
Use static planetary positions for navigation

### DIFF
--- a/components/solar-system-view.tsx
+++ b/components/solar-system-view.tsx
@@ -21,7 +21,6 @@ export interface OrbitPlanet extends Planet {
 function PlanetMesh({
   distance,
   size,
-  speed,
   inclination,
   color,
   // texture,
@@ -36,17 +35,16 @@ function PlanetMesh({
   const groupRef = useRef<THREE.Group>(null!)
   // const colorMap = useLoader(TextureLoader, texture)
 
-  useFrame(({ clock }) => {
-    const t = clock.getElapsedTime() * speed
+  useEffect(() => {
     const position = new THREE.Vector3(
-      Math.cos(t) * distance,
+      Math.cos(0) * distance,
       0,
-      Math.sin(t) * distance,
+      Math.sin(0) * distance,
     )
     position.applyAxisAngle(new THREE.Vector3(1, 0, 0), inclination)
     groupRef.current.position.copy(position)
     onPositionChange(position)
-  })
+  }, [distance, inclination, onPositionChange])
 
   return (
     <>

--- a/hooks/use-ship-navigation.ts
+++ b/hooks/use-ship-navigation.ts
@@ -26,11 +26,10 @@ export function useShipNavigation() {
   const updateShipPosition = (delta: number) => {
     if (!destinationPlanet) return
 
-    const t = (Date.now() / 1000) * destinationPlanet.speed
     const target = new THREE.Vector3(
-      Math.cos(t) * destinationPlanet.distance,
+      destinationPlanet.distance,
       0,
-      Math.sin(t) * destinationPlanet.distance,
+      0,
     )
     target.applyAxisAngle(
       new THREE.Vector3(1, 0, 0),


### PR DESCRIPTION
## Summary
- Fix PlanetMesh to set a planet's position once instead of updating every frame
- Update ship navigation to target planets' fixed coordinates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a30a16e68c8331ab30d342088e3795