### PR TITLE
Use random UUID for battle log entries

### DIFF
--- a/hooks/use-battle.ts
+++ b/hooks/use-battle.ts
@@ -105,8 +105,13 @@ export function useBattle() {
 
   const addExperience = useStore((s) => s.addExperience)
 
+  let logCounter = 0
+
   const createLog = (message: string, type: BattleLog["type"]): BattleLog => ({
-    id: Date.now().toString(),
+    id:
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${logCounter++}`,
     timestamp: Date.now(),
     message,
     type,


### PR DESCRIPTION
## Summary
- generate unique battle log IDs using `crypto.randomUUID` with timestamp fallback

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a321a1fdd4833197cabaf522b06d36