### PR TITLE
fix: prevent default context menu on planets

### DIFF
--- a/components/solar-system-view.tsx
+++ b/components/solar-system-view.tsx
@@ -52,7 +52,7 @@ function PlanetMesh({
       <group
         ref={groupRef}
         onContextMenu={(e) => {
-          e.preventDefault()
+          e.nativeEvent.preventDefault()
           onSelect?.()
         }}
       >


### PR DESCRIPTION
## Summary
- prevent browser context menu from appearing when right-clicking a planet

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint? https://nextjs.org/docs/app/api-reference/config/eslint)
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a324f43ff8833194bf6837ca6c7989