### PR TITLE
Avoid overlapping planet overlays

### DIFF
--- a/components/galaxy-map.tsx
+++ b/components/galaxy-map.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
+import { useState } from "react"
 import dynamic from "next/dynamic"
 import { StarMap } from "./star-map"
 import type { OrbitPlanet } from "./solar-system-view"
@@ -99,6 +100,15 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
     setShowProcessingInterface,
   } = useResourceOperations(selectedSystem)
 
+  const [nearbyPlanet, setNearbyPlanet] = useState<OrbitPlanet | null>(null)
+
+  const handleNearbyPlanetChange = (planet: OrbitPlanet | null) => {
+    setNearbyPlanet(planet)
+    if (!planet) {
+      clearSelectedPlanet()
+    }
+  }
+
   const handleStartMining = () => {
     if (!selectedSystem) return
     const target: MiningTarget = {
@@ -131,7 +141,11 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
   return (
     <div className="space-y-4">
       {selectedSystem?.id === playerLocation ? (
-        <SolarSystemView planets={systemPlanets} onPlanetSelect={handlePlanetSelect} />
+        <SolarSystemView
+          planets={systemPlanets}
+          onPlanetSelect={handlePlanetSelect}
+          onNearbyPlanetChange={handleNearbyPlanetChange}
+        />
       ) : (
         <StarMap
           starSystems={starSystems}
@@ -186,7 +200,9 @@ export default function GalaxyMap({ onBack }: GalaxyMapProps) {
         show={showProcessingInterface}
         onClose={() => setShowProcessingInterface(false)}
       />
-      <PlanetDetails planet={selectedPlanet} onClose={clearSelectedPlanet} />
+      {!nearbyPlanet && (
+        <PlanetDetails planet={selectedPlanet} onClose={clearSelectedPlanet} />
+      )}
     </div>
   )
 }

--- a/components/solar-system-view.tsx
+++ b/components/solar-system-view.tsx
@@ -392,9 +392,14 @@ function PlanetProximityDetector({
 interface SolarSystemViewProps {
   planets: OrbitPlanet[]
   onPlanetSelect?: (planet: OrbitPlanet) => void
+  onNearbyPlanetChange?: (planet: OrbitPlanet | null) => void
 }
 
-export function SolarSystemView({ planets, onPlanetSelect }: SolarSystemViewProps) {
+export function SolarSystemView({
+  planets,
+  onPlanetSelect,
+  onNearbyPlanetChange,
+}: SolarSystemViewProps) {
   const starPositions = useMemo(() => {
     const count = 1000
     const positions = new Float32Array(count * 3)
@@ -436,6 +441,7 @@ export function SolarSystemView({ planets, onPlanetSelect }: SolarSystemViewProp
     if (nearbyPlanet) {
       dismissedPlanetId.current = nearbyPlanet.id
       setNearbyPlanet(null)
+      onNearbyPlanetChange?.(null)
     }
   }
 
@@ -513,7 +519,10 @@ export function SolarSystemView({ planets, onPlanetSelect }: SolarSystemViewProp
           planetPositions={planetPositions}
           threshold={proximityThreshold}
           dismissedPlanetId={dismissedPlanetId}
-          onChange={setNearbyPlanet}
+          onChange={(planet) => {
+            setNearbyPlanet(planet)
+            onNearbyPlanetChange?.(planet)
+          }}
         />
 
         {firstPerson ? (


### PR DESCRIPTION
## Summary
- Track nearby planets in galaxy map to hide PlanetDetails when proximity menu is active
- Clear selected planet on proximity change to prevent stale overlays
- Notify galaxy map of proximity events from solar system view

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a426e6e07c8331825c8af35b798dd2