### PR TITLE
feat: add planet interaction callbacks

### DIFF
--- a/components/planet-interaction-menu.tsx
+++ b/components/planet-interaction-menu.tsx
@@ -7,9 +7,18 @@ import type { OrbitPlanet } from "./solar-system-view"
 interface PlanetInteractionMenuProps {
   planet: OrbitPlanet
   onClose: () => void
+  onExplore?: () => void
+  onTrade?: () => void
+  onMine?: () => void
 }
 
-export function PlanetInteractionMenu({ planet, onClose }: PlanetInteractionMenuProps) {
+export function PlanetInteractionMenu({
+  planet,
+  onClose,
+  onExplore,
+  onTrade,
+  onMine,
+}: PlanetInteractionMenuProps) {
   return (
     <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/50">
       <Card className="bg-slate-900 border-blue-600/50 p-6 max-w-sm w-full mx-4">
@@ -22,9 +31,15 @@ export function PlanetInteractionMenu({ planet, onClose }: PlanetInteractionMenu
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
-          <Button className="w-full">Explore</Button>
-          <Button className="w-full">Trade</Button>
-          <Button className="w-full">Mine</Button>
+          <Button className="w-full" onClick={onExplore}>
+            Explore
+          </Button>
+          <Button className="w-full" onClick={onTrade}>
+            Trade
+          </Button>
+          <Button className="w-full" onClick={onMine}>
+            Mine
+          </Button>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- expand planet interaction menu with explore, trade, and mine actions
- wire solar system view to mining, trading, and exploration handlers

## Testing
- `pnpm lint` *(fails: requires eslint configuration)*
- `pnpm run test` *(fails: missing script)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a42a537694833185a3dbc8e6a8a554